### PR TITLE
Fix the wrong require condition of TimelockExecutorBase::getCurrentState()

### DIFF
--- a/contracts/timelock/TimelockExecutorBase.sol
+++ b/contracts/timelock/TimelockExecutorBase.sol
@@ -101,7 +101,7 @@ abstract contract TimelockExecutorBase is ITimelockExecutor {
 
   /// @inheritdoc ITimelockExecutor
   function getCurrentState(uint256 actionsSetId) public view override returns (ActionsSetState) {
-    require(_actionsSetCounter >= actionsSetId, 'INVALID_ACTION_ID');
+    require(_actionsSetCounter > actionsSetId, 'INVALID_ACTION_ID');
     ActionsSet storage actionsSet = _actionsSets[actionsSetId];
     if (actionsSet.canceled) {
       return ActionsSetState.Canceled;

--- a/test/arc-timelock-full.ts
+++ b/test/arc-timelock-full.ts
@@ -101,6 +101,7 @@ makeSuite('ArcTimelock', setupTestEnvironment, (testEnv: TestEnv) => {
       expect(await arcTimelock.getMaximumDelay()).to.be.equal(ARC_TIMELOCK_CONFIG.MAXIMUM_DELAY);
       expect(await arcTimelock.getGuardian()).to.be.equal(ARC_TIMELOCK_CONFIG.GUARDIAN_ADDRESS);
       expect(await arcTimelock.getActionsSetCount()).to.be.equal(BigNumber.from(0));
+      await expect(arcTimelock.getCurrentState(BigNumber.from(0))).to.be.revertedWith('INVALID_ACTION_ID');
     });
 
     it('Release keys of the Market to ArcTimelock', async () => {

--- a/test/arc-timelock-params-update.ts
+++ b/test/arc-timelock-params-update.ts
@@ -105,6 +105,7 @@ makeSuite('ArcTimelock Parameters Update', setupTestEnvironment, (testEnv: TestE
       expect(await arcTimelock.getMaximumDelay()).to.be.equal(ARC_TIMELOCK_CONFIG.MAXIMUM_DELAY);
       expect(await arcTimelock.getGuardian()).to.be.equal(ARC_TIMELOCK_CONFIG.GUARDIAN_ADDRESS);
       expect(await arcTimelock.getActionsSetCount()).to.be.equal(BigNumber.from(0));
+      await expect(arcTimelock.getCurrentState(BigNumber.from(0))).to.be.revertedWith('INVALID_ACTION_ID');
     });
 
     it('Release keys of the Market to ArcTimelock', async () => {


### PR DESCRIPTION
Closes #1 